### PR TITLE
Organisms/TodoCardの作成2

### DIFF
--- a/src/components/Atoms/Input/index.jsx
+++ b/src/components/Atoms/Input/index.jsx
@@ -8,7 +8,7 @@ const Input = (props) => {
 
   useEffect(() => {
     if (inputRef.current) {
-      inputRef.current.value = props.defalutValue;
+      inputRef.current.value = props.defaultValue;
       inputRef.current.focus();
       inputRef.current.onblur = (e) => {
         const inputText = e.target.value;

--- a/src/components/Atoms/Input/story.jsx
+++ b/src/components/Atoms/Input/story.jsx
@@ -16,6 +16,6 @@ const Template = (args) => <Component {...args} />;
 export const Default = Template.bind({});
 
 Default.args = {
-  defalutValue: "",
+  defaultValue: "",
   onEditComplete: (text) => console.log(`edit complete:\n${text}`),
 };

--- a/src/components/Molecules/Task/index.jsx
+++ b/src/components/Molecules/Task/index.jsx
@@ -7,13 +7,13 @@ import COLOR from "../../../variables/color";
 import TEXT from "../../../variables/texts";
 
 const Task = ({
-  defalutValue,
-  defalutIsEditing,
+  defaultValue,
+  defaultIsEditing,
   onEditComplete,
   onTaskComplete,
 }) => {
   // タスクが編集中かどうかの状態管理
-  const [isEditing, setIsEditing] = useState(defalutIsEditing);
+  const [isEditing, setIsEditing] = useState(defaultIsEditing);
 
   const handleCompleteTask = () => {
     setIsEditing(false);
@@ -34,12 +34,12 @@ const Task = ({
       <CheckBox onClick={handleCompleteTask} />
       {isEditing ? (
         <Input
-          defalutValue={defalutValue}
+          defaultValue={defaultValue}
           onEditComplete={handleCompleteEdit}
         />
       ) : (
         <StyledTaskNameArea>
-          <StyledTaskTitle>{defalutValue}</StyledTaskTitle>
+          <StyledTaskTitle>{defaultValue}</StyledTaskTitle>
           <EditButton onClick={onEditStart} />
         </StyledTaskNameArea>
       )}

--- a/src/components/Molecules/Task/story.jsx
+++ b/src/components/Molecules/Task/story.jsx
@@ -16,8 +16,8 @@ const Template = (args) => <Component {...args} />;
 export const Default = Template.bind({});
 
 Default.args = {
-  defalutValue: "taskname",
-  defalutIsEditing: false,
+  defaultValue: "taskName",
+  defaultIsEditing: false,
   onTaskComplete: () => console.log("task complete"),
-  onEditComplete: (text) => console.log(`taaskname changed: ${text}`),
+  onEditComplete: (text) => console.log(`taskName changed: ${text}`),
 };

--- a/src/components/Organisms/TodoCard/index.jsx
+++ b/src/components/Organisms/TodoCard/index.jsx
@@ -1,0 +1,98 @@
+import React, { useRef, useEffect, useState } from "react";
+import styled from "styled-components";
+import AddTaskButton from "../../Atoms/AddTaskButton/index";
+import Task from "../../Molecules/Task/index";
+import COLOR from "../../../variables/color";
+
+const TodoCard = () => {
+  const [todoTask, setTodoTask] = useState([]);
+  const [taskAddOREdit, setAddOREdit] = useState(false);
+
+  let todoTaskList = [];
+  let todoStateTask = [];
+
+  const handleTaskComplete = (id) => {
+    let completedTask = todoTask.map((task) => {
+      if (task.id === id) {
+        task.state = "DONE";
+      }
+      return task;
+    });
+    setTodoTask(completedTask);
+  };
+
+  const handleEditComplete = (id, taskName) => {
+    let edittedTask = [];
+    if (taskName === "") {
+      edittedTask = todoTask.filter((task) => {
+        return task.id !== id;
+      });
+    } else {
+      edittedTask = todoTask.map((task) => {
+        if (task.id === id) {
+          task.name = taskName;
+        }
+        return task;
+      });
+    }
+    setTodoTask(edittedTask);
+    setAddOREdit(false);
+  };
+
+  // task.stateがTODOのものだけ抽出する
+  todoStateTask = todoTask.filter((task) => {
+    return task.state === "TODO";
+  });
+
+  todoTaskList = todoStateTask.map((task, index) => {
+    // addTask()が実行されたとき、todoTaskの一番後ろのコンポーネントだけにdefaultIsEditingを渡す
+    return (
+      <StyledTodoListItem key={index}>
+        <Task
+          key={task.id}
+          defalutValue={task.name}
+          defalutIsEditing={
+            taskAddOREdit ? task.id === todoTask.length - 1 : false
+          }
+          onEditComplete={(taskName) => handleEditComplete(task.id, taskName)}
+          onTaskComplete={() => handleTaskComplete(task.id)}
+        />
+      </StyledTodoListItem>
+    );
+  });
+
+  const addTask = () => {
+    const idNum = todoTask.length;
+    setTodoTask((todoTask) => [
+      ...todoTask,
+      { id: idNum, name: "", state: "TODO" },
+    ]);
+    setAddOREdit(true);
+  };
+
+  return (
+    <StyledTodoCard>
+      <AddTaskButton onClick={addTask} />
+      <StyledTodoList>{todoTaskList}</StyledTodoList>
+    </StyledTodoCard>
+  );
+};
+
+export default TodoCard;
+
+const StyledTodoCard = styled.div`
+  padding: 20px;
+  border-radius: 4px;
+  background-color: ${COLOR.DEEP_BLUE_GRAY};
+`;
+
+const StyledTodoList = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-self: stretch;
+  box-sizing: border-box;
+`;
+
+const StyledTodoListItem = styled.div`
+  margin-top: 10px;
+`;

--- a/src/components/Organisms/TodoCard/index.jsx
+++ b/src/components/Organisms/TodoCard/index.jsx
@@ -5,75 +5,66 @@ import Task from "../../Molecules/Task/index";
 import COLOR from "../../../variables/color";
 
 const TodoCard = () => {
-  const [todoTask, setTodoTask] = useState([]);
-  const [taskAddOREdit, setAddOREdit] = useState(false);
+  const [taskList, setTaskList] = useState([]);
+  const [taskAddOrEdit, setAddOrEdit] = useState(false);
 
-  let todoTaskList = [];
-  let todoStateTask = [];
+  // タスクのStateが"TODO"のものを抽出
+  const todoStateTask = taskList.filter((task) => {
+    return task.state === "TODO";
+  });
 
-  const handleTaskComplete = (id) => {
-    let completedTask = todoTask.map((task) => {
-      if (task.id === id) {
+  // タスクを追加したときの関数(AddTaskButtonを押したとき)
+  const addTask = () => {
+    //const idNum = taskList.length;
+    setTaskList((taskList) => [...taskList, { name: "", state: "TODO" }]);
+    setAddOrEdit(true);
+  };
+
+  // タスクが完了したときの関数(CheckBoxにチェックを入れたとき)
+  const handleTaskComplete = (taskIndex) => {
+    const completedTask = taskList.map((task, index) => {
+      if (index === taskIndex) {
         task.state = "DONE";
       }
       return task;
     });
-    setTodoTask(completedTask);
+    setTaskList(completedTask);
   };
 
-  const handleEditComplete = (id, taskName) => {
-    let edittedTask = [];
+  // タスクの編集が完了したときの関数
+  const handleEditComplete = (taskIndex, taskName) => {
+    let editedTask = [];
     if (taskName === "") {
-      edittedTask = todoTask.filter((task) => {
-        return task.id !== id;
+      editedTask = taskList.filter((task, index) => {
+        return index !== taskIndex;
       });
     } else {
-      edittedTask = todoTask.map((task) => {
-        if (task.id === id) {
+      editedTask = taskList.map((task, index) => {
+        if (index === taskIndex) {
           task.name = taskName;
         }
         return task;
       });
     }
-    setTodoTask(edittedTask);
-    setAddOREdit(false);
-  };
-
-  // task.stateがTODOのものだけ抽出する
-  todoStateTask = todoTask.filter((task) => {
-    return task.state === "TODO";
-  });
-
-  todoTaskList = todoStateTask.map((task, index) => {
-    // addTask()が実行されたとき、todoTaskの一番後ろのコンポーネントだけにdefaultIsEditingを渡す
-    return (
-      <StyledTodoListItem key={index}>
-        <Task
-          key={task.id}
-          defalutValue={task.name}
-          defalutIsEditing={
-            taskAddOREdit ? task.id === todoTask.length - 1 : false
-          }
-          onEditComplete={(taskName) => handleEditComplete(task.id, taskName)}
-          onTaskComplete={() => handleTaskComplete(task.id)}
-        />
-      </StyledTodoListItem>
-    );
-  });
-
-  const addTask = () => {
-    const idNum = todoTask.length;
-    setTodoTask((todoTask) => [
-      ...todoTask,
-      { id: idNum, name: "", state: "TODO" },
-    ]);
-    setAddOREdit(true);
+    setTaskList(editedTask);
+    setAddOrEdit(false);
   };
 
   return (
     <StyledTodoCard>
       <AddTaskButton onClick={addTask} />
-      <StyledTodoList>{todoTaskList}</StyledTodoList>
+      <StyledTodoList>
+        {todoStateTask.map((task, index) => (
+          <StyledTodoListItem key={index}>
+            <Task
+              defaultValue={task.name}
+              defaultIsEditing={true}
+              onEditComplete={(taskName) => handleEditComplete(index, taskName)}
+              onTaskComplete={() => handleTaskComplete(index)}
+            />
+          </StyledTodoListItem>
+        ))}
+      </StyledTodoList>
     </StyledTodoCard>
   );
 };

--- a/src/components/Organisms/TodoCard/index.jsx
+++ b/src/components/Organisms/TodoCard/index.jsx
@@ -6,7 +6,6 @@ import COLOR from "../../../variables/color";
 
 const TodoCard = () => {
   const [taskList, setTaskList] = useState([]);
-  const [taskAddOrEdit, setAddOrEdit] = useState(false);
 
   // タスクのStateが"TODO"のものを抽出
   const todoStateTask = taskList.filter((task) => {
@@ -15,18 +14,13 @@ const TodoCard = () => {
 
   // タスクを追加したときの関数(AddTaskButtonを押したとき)
   const addTask = () => {
-    //const idNum = taskList.length;
     setTaskList((taskList) => [...taskList, { name: "", state: "TODO" }]);
-    setAddOrEdit(true);
   };
 
   // タスクが完了したときの関数(CheckBoxにチェックを入れたとき)
   const handleTaskComplete = (taskIndex) => {
-    const completedTask = taskList.map((task, index) => {
-      if (index === taskIndex) {
-        task.state = "DONE";
-      }
-      return task;
+    const completedTask = taskList.filter((task, index) => {
+      return index !== taskIndex;
     });
     setTaskList(completedTask);
   };
@@ -47,7 +41,6 @@ const TodoCard = () => {
       });
     }
     setTaskList(editedTask);
-    setAddOrEdit(false);
   };
 
   return (

--- a/src/components/Organisms/TodoCard/story.jsx
+++ b/src/components/Organisms/TodoCard/story.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+import Component from "./index";
+
+export default {
+  component: Component,
+  title: "Organisms/TodoCard",
+  parameters: {
+    backgrounds: {
+      default: "dark",
+    },
+  },
+};
+
+const Template = (args) => <Component {...args} />;
+
+export const Default = Template.bind({});


### PR DESCRIPTION
## Organisms/TodoCardの作成

Atoms/Inputの方で修正を加えたので、新しくブランチを切りました
前回までのTodoCardのPRは"Organisms/TodoCardの作成1"の方を見て頂ければと思います
・Enter押したときに、エラーができていたので、atoms/inputの方で、修正したのを適用させています
・タスクを追加したときに、追加したタスクにだけdefaultIsEditingが適用されるように修正しました

- [x] お手本通りの見た目であるか　ホバー時の挙動、レスポンシブ対応など要確認
- [x] ブランチ名、ファイル名、クラス名、インデントなど、コーディング規則を逸脱していないか
- [x] 記述の重複はないか